### PR TITLE
fix(check): add missing module

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -16,6 +16,7 @@ in rec {
     modules = [
       ../modules/image/repart-verity-store.nix
       ../modules/image/initrd-repart-expand.nix
+      ../modules/image/sysupdate-verity-store.nix
       ../modules/profiles/minimal.nix
       ../modules/profiles/image-based.nix
       ../modules/profiles/server.nix


### PR DESCRIPTION
I stumbled over this very interesting project and am just fiddling around. I noticed that checks were failing with

```
    error: The option `system.image.updates' does not exist. Definition values:
       - In `/nix/store/ylp7g3dmsqgg2m3qvlr8m91vp2rs15pq-source/tests/common.nix':
           {
             url = "http://server.test/";
           }
```

It runs now but the update test still fails, but I guess that is a setup problem.